### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ export MQTT_CLIENT_ID=openweather-mqtt-service
 Launch application:
 
 ```sh
-python ./openweather_mqtt.py
+python3 ./openweather_mqtt.py
 ```
 
 You should see output printed:


### PR DESCRIPTION
Run with python3 to ensure correct run. If both Python 3 and Python 2 are installed and Python 2 is default, script produces syntax errors.